### PR TITLE
Add Executable Flag When Script Does Not Have The Flag

### DIFF
--- a/src/stexus/experiment/script.py
+++ b/src/stexus/experiment/script.py
@@ -1,4 +1,4 @@
-import subprocess
+import subprocess, os, stat
 from optuna import Trial
 from .base import BaseExperiment
 from .exception import ExperimentException
@@ -13,6 +13,16 @@ class ExperimentWithScript(BaseExperiment):
         super().__init__(config, adjust)
 
     def _run_script(self) -> None:
+        if os.path.isfile(self._config["experiment"]["args"]) and not os.access(self._config["experiment"]["args"], os.X_OK):
+            """if args is file and it doesn't have executable flag,
+            add executable flag.
+            """
+            os.chmod(
+                self._config["experiment"]["args"],
+                os.stat(
+                    self._config["experiment"]["args"]
+                ).st_mode | stat.S_IEXEC
+            )
         subprocess.run(
             args=self._config["experiment"]["args"],
             check=not self._config["experiment"].get("ignore_exit_code", False),

--- a/tests/test_experiment_with_script.py
+++ b/tests/test_experiment_with_script.py
@@ -13,7 +13,7 @@ class MockAdvocator():
     def __init__(self) -> None:
         return
 
-def test_run_script(tmp_path: pathlib.Path):
+def test_run_script_with_executable_flag(tmp_path: pathlib.Path):
     mock_score = tmp_path / 'score'
     mock_score.write_text('1')
 
@@ -27,6 +27,40 @@ def test_run_script(tmp_path: pathlib.Path):
         )
         curr_fstat = os.stat(str(script.absolute()))
         os.chmod(str(script.absolute()), curr_fstat.st_mode | stat.S_IEXEC)
+    elif system == 'Windows':
+        script = tmp_path / 'script.bat'
+        script.write_text(
+            '@echo off\n'
+            'echo Hello, World'
+        )
+    else:
+        raise Exception('system is unsupported')
+
+    config = {
+        'experiment': {
+            'args': str(script.absolute()),
+            'ignore_exit_code': False
+        },
+        'score_path': str(mock_score.absolute())
+    }
+
+    experiment = ExperimentWithScript(config, MockAdjust()) # type: ignore
+    score = experiment.experiment(MockAdvocator) # type: ignore
+    assert score == 1
+
+
+def test_run_script_without_executable_flag(tmp_path: pathlib.Path):
+    mock_score = tmp_path / 'score'
+    mock_score.write_text('1')
+
+    # this is platform dependant
+    system = platform.system()
+
+    if system == 'Linux' or system == 'Darwin':
+        script = tmp_path / 'script'
+        script.write_text(
+            'echo "Hello, World"'
+        )
     elif system == 'Windows':
         script = tmp_path / 'script.bat'
         script.write_text(


### PR DESCRIPTION
Solves problem where a script is also the rendered template. a rendered template does not have executable flag, so if it's also ran as a script we need to add executable flag to it.

Solves #9 